### PR TITLE
Change addresses of contracts

### DIFF
--- a/packages/web/components/autonomy/order-history.tsx
+++ b/packages/web/components/autonomy/order-history.tsx
@@ -72,7 +72,7 @@ const OrderRow = ({ order }: { order: Order }) => {
         "",
         { gas: "350000" },
         undefined,
-        (e) => console.log(e)
+        (e: any) => console.log(e)
       );
     } catch (err) {
       console.log(err);

--- a/packages/web/config/autonomy.ts
+++ b/packages/web/config/autonomy.ts
@@ -13,13 +13,13 @@ export const SUBQUERY_BACKUP_ENDPOINTS: { [chainId: string]: string } = {
 export const REGISTRY_ADDRESSES: { [chainId: string]: string } = {
   "osmosis-1": "",
   "osmo-test-4":
-    "osmo1zynr26u48vdjrcuxkgswfhcx4zh5lw58qshzycykf33p7fp5y32qkydwrp",
+    "osmo1wuuyz9tlazx96v9vl8q9q9cmqwz7z72kyhcqu0nuauszgkxa572ss60ps4",
 };
 
 export const WRAPPER_ADDRESSES: { [chainId: string]: string } = {
   "osmosis-1": "",
   "osmo-test-4":
-    "osmo1dwpdh2clk7c8csf9ql2xj36336xsryyg4j7622jhaert9htp48gsh8u9ve",
+    "osmo14pcgaxpx4x34fr0dxc5p6fw2aww84wrgycykkctelhv4xrg4ytgq3jjdua",
 };
 export const ENABLE_AUTONOMY = true;
 // process.env.NEXT_PUBLIC_ENABLE_AUTONOMY === "enabled";


### PR DESCRIPTION
This PR changes addresses of registry and wrapper addresses. Here is the new information about currently deployed contracts to Osmosis's testnet:

RegistryStake:
	code_id: 5953
	admin: osmo174wdq55gjaryryjlwew0s2wurssrle4vthk4gl
	contract_address: osmo1wuuyz9tlazx96v9vl8q9q9cmqwz7z72kyhcqu0nuauszgkxa572ss60ps4

WrapperOsmosis:
	code_id: 5955
	admin: osmo174wdq55gjaryryjlwew0s2wurssrle4vthk4gl
	contract_address: osmo14pcgaxpx4x34fr0dxc5p6fw2aww84wrgycykkctelhv4xrg4ytgq3jjdua
